### PR TITLE
feat: add `appearance` deprecated `ondark` #67

### DIFF
--- a/apiExamples/inverseAppearance-2.html
+++ b/apiExamples/inverseAppearance-2.html
@@ -1,0 +1,1 @@
+<auro-lockup appearance="inverse" variant="oneworld"></auro-lockup>

--- a/apiExamples/inverseAppearance-3.html
+++ b/apiExamples/inverseAppearance-3.html
@@ -1,0 +1,1 @@
+<auro-lockup appearance="inverse" standard variant="oneworld"></auro-lockup>

--- a/apiExamples/inverseAppearance.html
+++ b/apiExamples/inverseAppearance.html
@@ -1,4 +1,4 @@
-<auro-lockup onDark>
+<auro-lockup appearance="inverse">
   <span slot="title">Product Name</span>
   <span slot="subtitle">Powered by Partner Name</span>
 </auro-lockup>

--- a/apiExamples/inverseAppearanceExample.html
+++ b/apiExamples/inverseAppearanceExample.html
@@ -1,0 +1,1 @@
+<auro-lockup appearance="inverse"></auro-lockup>

--- a/apiExamples/onDark-2.html
+++ b/apiExamples/onDark-2.html
@@ -1,1 +1,0 @@
-<auro-lockup onDark variant="oneworld"></auro-lockup>

--- a/apiExamples/onDark-3.html
+++ b/apiExamples/onDark-3.html
@@ -1,1 +1,0 @@
-<auro-lockup onDark standard variant="oneworld"></auro-lockup>

--- a/apiExamples/onDarkExample.html
+++ b/apiExamples/onDarkExample.html
@@ -1,1 +1,0 @@
-<auro-lockup onDark></auro-lockup>

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,18 +4,19 @@ The auro-lockup element is a standardized custom element for the use in headers 
 
 ## Attributes
 
-| Attribute | Type      | Description       |
-|-----------|-----------|-------------------|
-| `onDark`  | `Boolean` | Toggle onDark UI. |
+| Attribute | Type      | Description                                      |
+|-----------|-----------|--------------------------------------------------|
+| `onDark`  | `Boolean` | DEPRECATED - Use `appearance="inverse"` instead. |
 
 ## Properties
 
-| Property   | Attribute  | Type      | Default | Description                                      |
-|------------|------------|-----------|---------|--------------------------------------------------|
-| `oneworld` | `oneworld` | `boolean` | false   | (DEPRECATED) Replaces product name and tag line with Oneworld logo. |
-| `path`     | `path`     | `string`  | "/"     | URL path for lockup link.                        |
-| `standard` | `standard` | `boolean` | false   | Uses the standard Alaska logo in place of the official logo, requires use of `oneWorld` attribute. |
-| `variant`  | `variant`  | `string`  |         | Sets lockup variant option. Only possible value is `oneworld`. |
+| Property     | Attribute    | Type      | Default     | Description                                      |
+|--------------|--------------|-----------|-------------|--------------------------------------------------|
+| `appearance` | `appearance` | `string`  | "'default'" | Defines whether the component will be on lighter or darker backgrounds. |
+| `oneworld`   | `oneworld`   | `boolean` | false       | (DEPRECATED) Replaces product name and tag line with Oneworld logo. |
+| `path`       | `path`       | `string`  | "/"         | URL path for lockup link.                        |
+| `standard`   | `standard`   | `boolean` | false       | Uses the standard Alaska logo in place of the official logo, requires use of `oneWorld` attribute. |
+| `variant`    | `variant`    | `string`  |             | Sets lockup variant option. Only possible value is `oneworld`. |
 
 ## Slots
 

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -7,18 +7,18 @@ See the following examples for use-case illustrations of API options.
 
 ### Attribute Examples
 
-#### `onDark`
+#### Visual state on dark background
 
-Use the `onDark` attribute for the proper presentation on a darker background.
+Use the `appearance="inverse"` attribute for the proper presentation on a darker background.
 
 <div class="exampleWrapper--ondark">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/onDarkExample.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/inverseAppearanceExample.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/onDarkExample.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/inverseAppearanceExample.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/docs/partials/index.md
+++ b/docs/partials/index.md
@@ -48,45 +48,45 @@ The `standard` property is only supported with the `oneworld` option.
 
 </auro-accordion>
 
-## auro-lockup onDark
+## auro-lockup appearance options
 
-For lockup use with dark backgrounds or a dark mode, use the `onDark` attribute.
+For lockup use with dark backgrounds or a dark mode, use the `appearance="inverse"` attribute.
 
 <div class="exampleWrapper--ondark">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/onDark.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/inverseAppearance.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/onDark.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/inverseAppearance.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>
 
 <div class="exampleWrapper--ondark">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/onDark-2.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/inverseAppearance-2.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/onDark-2.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/inverseAppearance-2.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>
 
 <div class="exampleWrapper--ondark">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/onDark-3.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/inverseAppearance-3.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/onDark-3.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/inverseAppearance-3.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/scripts/wca/auro-lockup.js
+++ b/scripts/wca/auro-lockup.js
@@ -3,9 +3,6 @@ import { AuroLockup } from "../../src/auro-lockup.js";
 /**
  * The auro-lockup element is a standardized custom element for the use in headers of Alaska Airlines extended experiences.
  *
- * @attr {Boolean} onDark - Toggle onDark UI.
- * @slot title - Set title for lockup
- * @slot subtitle - Set sub-title for lockup
  */
 class AuroLockupWCA extends AuroLockup {}
 

--- a/src/auro-lockup.js
+++ b/src/auro-lockup.js
@@ -17,6 +17,13 @@ import colorCss from "./styles/color.scss";
 import styleCss from "./styles/style.scss";
 import tokensCss from "./styles/tokens.scss";
 
+/**
+ * The auro-lockup element is a standardized custom element for the use in headers of Alaska Airlines extended experiences.
+ *
+ * @slot title - Set title for lockup
+ * @slot subtitle - Set sub-title for lockup
+ * @attr {Boolean} onDark - DEPRECATED - Use `appearance="inverse"` instead.
+ */
 export class AuroLockup extends LitElement {
   constructor() {
     super();
@@ -35,6 +42,16 @@ export class AuroLockup extends LitElement {
   static get properties() {
     return {
       // ...super.properties,
+
+      /**
+       * Defines whether the component will be on lighter or darker backgrounds.
+       * @property {'default', 'inverse'}
+       * @default 'default'
+       */
+      appearance: {
+        type: String,
+        reflect: true
+      },
 
       /**
        * (DEPRECATED) Replaces product name and tag line with Oneworld logo.

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -24,7 +24,8 @@
   }
 }
 
-:host([onDark]) {
+:host([onDark]),
+:host([appearance="inverse"]) {
   --ds-auro-lockup-alaska-logo-color: #FFF; // Hard-coded to prevent customization of Alaska Airlines logo color
   --ds-auro-lockup-divider-color: var(--ds-basic-color-border-divider-inverse, #{v.$ds-basic-color-border-divider-inverse});
   --ds-auro-lockup-subtitle-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});


### PR DESCRIPTION
# Alaska Airlines Pull Request

Close #67 

This is to replace `onDark` attr with `appearance` attr. 
- Adding `appearance` with its default value `default`
- Mark `onDark` as deprecated in the api table
- Replace `onDark` with `appearance="inverse"` in all examples 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
